### PR TITLE
[translation] Fixes in osh/cmd_exec.py.

### DIFF
--- a/build/mycpp.sh
+++ b/build/mycpp.sh
@@ -319,10 +319,9 @@ readonly TRANSLATE=(
   # crash:
   # list comprehensions and value.AssocArray typing
   # should be Dict[str, str] for now
-  $REPO_ROOT/osh/word_eval.py
+  #$REPO_ROOT/osh/word_eval.py
 
-  # has Union because of cmd_val
-  #$REPO_ROOT/osh/cmd_exec.py
+  $REPO_ROOT/osh/cmd_exec.py
 )
 
 # From types/more-oil-manifest.txt

--- a/doc/data-model.md
+++ b/doc/data-model.md
@@ -326,12 +326,22 @@ Oil supports various shell and bash operations to view the interpretr state.
 
 Pretty prints state.
 
-## Future Work: The Oil Data Model
 
-- Similar to Python and JavaScript
-- Garbage Collection
-- JSON serialization
-- Typed Arrays and Data Frames
+## `cmd_value` for shell builtins
+
+Another important type:
+
+```
+  assign_arg = (lvalue lval, value? rval, int spid)
+
+  cmd_value =
+    Argv(string* argv, int* arg_spids, command__BraceGroup? block)
+  | Assign(builtin builtin_id,
+           string* argv, int* arg_spids,
+           assign_arg* pairs)
+```
+
+<!-- TODO: change BraceGroup to something more accurate -->
 
 ## Links
 


### PR DESCRIPTION
Now that we got rid of the Union, there are some "boolean context"
fixes.

It now barfs on the ArithEvaluator, just like osh/word_eval.py.

- Unrelated: start documenting cmd_value in the data model, since it's
  important.